### PR TITLE
fix: replaced component scans with auto configurations

### DIFF
--- a/activiti-core-test/activiti-core-test-assertions/pom.xml
+++ b/activiti-core-test/activiti-core-test-assertions/pom.xml
@@ -44,10 +44,6 @@
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
@@ -55,5 +51,15 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
     </dependency>
+
+    <!-- Optional -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
+    
+    <!-- Test -->    
+    
   </dependencies>
 </project>

--- a/activiti-spring-connector/pom.xml
+++ b/activiti-spring-connector/pom.xml
@@ -28,15 +28,18 @@
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
+    <!-- Optional -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
 
+    <!-- Test -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/activiti-spring-connector/src/main/java/org/activiti/core/common/spring/connector/autoconfigure/ConnectorAutoConfiguration.java
+++ b/activiti-spring-connector/src/main/java/org/activiti/core/common/spring/connector/autoconfigure/ConnectorAutoConfiguration.java
@@ -16,10 +16,6 @@
 
 package org.activiti.core.common.spring.connector.autoconfigure;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.core.common.model.connector.ConnectorDefinition;
 import org.activiti.core.common.spring.connector.ConnectorDefinitionService;
@@ -27,12 +23,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.support.ResourcePatternResolver;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
 @Configuration
-@ComponentScan(basePackages = "org.activiti.core.common.spring.connector")
 public class ConnectorAutoConfiguration {
 
     @Bean
@@ -43,11 +41,13 @@ public class ConnectorAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public ConnectorDefinitionService connectorDefinitionService(@Value("${activiti.connectors.dir:classpath:/connectors/}") String connectorRoot, ObjectMapper objectMapper, ResourcePatternResolver resourceLoader) {
         return new ConnectorDefinitionService(connectorRoot, objectMapper, resourceLoader);
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public List<ConnectorDefinition> connectorDefinitions(ConnectorDefinitionService connectorDefinitionService) throws IOException {
         List<ConnectorDefinition> connectorDefinitions = connectorDefinitionService.get();
         return connectorDefinitions == null? Collections.emptyList() : connectorDefinitions;

--- a/activiti-spring-identity/pom.xml
+++ b/activiti-spring-identity/pom.xml
@@ -28,10 +28,6 @@
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
@@ -41,6 +37,15 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    
+    <!-- Optional -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
+    
+    <!-- Test -->    
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/activiti-spring-identity/pom.xml
+++ b/activiti-spring-identity/pom.xml
@@ -16,12 +16,8 @@
       <artifactId>activiti-api-runtime-shared</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-security</artifactId>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/activiti-spring-identity/src/main/java/org/activiti/core/common/spring/identity/ActivitiUserGroupManagerImpl.java
+++ b/activiti-spring-identity/src/main/java/org/activiti/core/common/spring/identity/ActivitiUserGroupManagerImpl.java
@@ -1,14 +1,12 @@
 package org.activiti.core.common.spring.identity;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.stereotype.Component;
 
-@Component
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class ActivitiUserGroupManagerImpl implements UserGroupManager {
 
     private final UserDetailsService userDetailsService;

--- a/activiti-spring-identity/src/main/java/org/activiti/core/common/spring/identity/config/ActivitiSpringIdentityAutoConfiguration.java
+++ b/activiti-spring-identity/src/main/java/org/activiti/core/common/spring/identity/config/ActivitiSpringIdentityAutoConfiguration.java
@@ -1,0 +1,19 @@
+package org.activiti.core.common.spring.identity.config;
+
+import org.activiti.api.runtime.shared.identity.UserGroupManager;
+import org.activiti.core.common.spring.identity.ActivitiUserGroupManagerImpl;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+@Configuration
+public class ActivitiSpringIdentityAutoConfiguration {
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public UserGroupManager userGroupManager(UserDetailsService userDetailsService) {
+        return new ActivitiUserGroupManagerImpl(userDetailsService);
+    }
+
+}

--- a/activiti-spring-identity/src/main/resources/META-INF/spring.factories
+++ b/activiti-spring-identity/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.activiti.core.common.spring.identity.config.ActivitiSpringIdentityAutoConfiguration

--- a/activiti-spring-identity/src/test/java/org/activiti/core/common/spring/identity/ActivitiUserGroupManagerImplIT.java
+++ b/activiti-spring-identity/src/test/java/org/activiti/core/common/spring/identity/ActivitiUserGroupManagerImplIT.java
@@ -40,7 +40,6 @@ public class ActivitiUserGroupManagerImplIT {
     }
 
     @org.springframework.context.annotation.Configuration
-    @ComponentScan("org.activiti.core.common.spring.identity")
     public static class Configuration {
 
     }

--- a/activiti-spring-identity/src/test/java/org/activiti/core/common/spring/identity/ActivitiUserGroupManagerImplIT.java
+++ b/activiti-spring-identity/src/test/java/org/activiti/core/common/spring/identity/ActivitiUserGroupManagerImplIT.java
@@ -16,15 +16,14 @@
 
 package org.activiti.core.common.spring.identity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
@@ -39,8 +38,4 @@ public class ActivitiUserGroupManagerImplIT {
         assertThat(userGroupManager.getUserRoles("admin")).contains("ACTIVITI_ADMIN");
     }
 
-    @org.springframework.context.annotation.Configuration
-    public static class Configuration {
-
-    }
 }

--- a/activiti-spring-project/pom.xml
+++ b/activiti-spring-project/pom.xml
@@ -29,14 +29,18 @@
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
+    <!-- Optional -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
+    
+    <!-- Test -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/activiti-spring-security-policies/pom.xml
+++ b/activiti-spring-security-policies/pom.xml
@@ -27,10 +27,15 @@
             <groupId>org.activiti.api</groupId>
             <artifactId>activiti-api-runtime-shared</artifactId>
         </dependency>
+        
+        <!-- Optional -->
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-autoconfigure</artifactId>
+          <optional>true</optional>
         </dependency>
+        
+        <!-- Test -->    
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>

--- a/activiti-spring-security-policies/pom.xml
+++ b/activiti-spring-security-policies/pom.xml
@@ -51,5 +51,10 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-configuration-processor</artifactId>
+          <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>

--- a/activiti-spring-security-policies/src/main/java/org/activiti/core/common/spring/security/policies/ProcessSecurityPoliciesManagerImpl.java
+++ b/activiti-spring-security-policies/src/main/java/org/activiti/core/common/spring/security/policies/ProcessSecurityPoliciesManagerImpl.java
@@ -1,23 +1,21 @@
 package org.activiti.core.common.spring.security.policies;
 
+import org.activiti.api.process.model.payloads.GetProcessDefinitionsPayload;
+import org.activiti.api.process.model.payloads.GetProcessInstancesPayload;
+import org.activiti.api.runtime.shared.identity.UserGroupManager;
+import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.springframework.beans.factory.annotation.Value;
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.activiti.api.runtime.shared.identity.UserGroupManager;
-import org.activiti.api.process.model.payloads.GetProcessDefinitionsPayload;
-import org.activiti.api.process.model.payloads.GetProcessInstancesPayload;
-import org.activiti.api.runtime.shared.security.SecurityManager;
-import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
-@Component
 public class ProcessSecurityPoliciesManagerImpl extends BaseSecurityPoliciesManagerImpl implements ProcessSecurityPoliciesManager{
 
-    private final SecurityPoliciesProcessDefinitionRestrictionApplier processDefinitionRestrictionApplier;
+    private final SecurityPoliciesRestrictionApplier<GetProcessDefinitionsPayload> processDefinitionRestrictionApplier;
 
-    private final SecurityPoliciesProcessInstanceRestrictionApplier processInstanceRestrictionApplier;
+    private final SecurityPoliciesRestrictionApplier<GetProcessInstancesPayload> processInstanceRestrictionApplier;
 
     @Value("${spring.application.name:application}")
     private String applicationName;
@@ -25,8 +23,8 @@ public class ProcessSecurityPoliciesManagerImpl extends BaseSecurityPoliciesMana
     public ProcessSecurityPoliciesManagerImpl(UserGroupManager userGroupManager,
                                               SecurityManager securityManager,
                                               SecurityPoliciesProperties securityPoliciesProperties,
-                                              SecurityPoliciesProcessDefinitionRestrictionApplier processDefinitionRestrictionApplier,
-                                              SecurityPoliciesProcessInstanceRestrictionApplier processInstanceRestrictionApplier) {
+                                              SecurityPoliciesRestrictionApplier<GetProcessDefinitionsPayload> processDefinitionRestrictionApplier,
+                                              SecurityPoliciesRestrictionApplier<GetProcessInstancesPayload> processInstanceRestrictionApplier) {
         super(userGroupManager, securityManager, securityPoliciesProperties);
         this.processDefinitionRestrictionApplier = processDefinitionRestrictionApplier;
         this.processInstanceRestrictionApplier = processInstanceRestrictionApplier;

--- a/activiti-spring-security-policies/src/main/java/org/activiti/core/common/spring/security/policies/SecurityPoliciesProcessDefinitionRestrictionApplier.java
+++ b/activiti-spring-security-policies/src/main/java/org/activiti/core/common/spring/security/policies/SecurityPoliciesProcessDefinitionRestrictionApplier.java
@@ -16,14 +16,12 @@
 
 package org.activiti.core.common.spring.security.policies;
 
+import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
+import org.activiti.api.process.model.payloads.GetProcessDefinitionsPayload;
+
 import java.util.Set;
 import java.util.UUID;
 
-import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
-import org.activiti.api.process.model.payloads.GetProcessDefinitionsPayload;
-import org.springframework.stereotype.Component;
-
-@Component
 public class SecurityPoliciesProcessDefinitionRestrictionApplier implements SecurityPoliciesRestrictionApplier<GetProcessDefinitionsPayload> {
 
     @Override

--- a/activiti-spring-security-policies/src/main/java/org/activiti/core/common/spring/security/policies/SecurityPoliciesProcessInstanceRestrictionApplier.java
+++ b/activiti-spring-security-policies/src/main/java/org/activiti/core/common/spring/security/policies/SecurityPoliciesProcessInstanceRestrictionApplier.java
@@ -16,14 +16,12 @@
 
 package org.activiti.core.common.spring.security.policies;
 
+import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
+import org.activiti.api.process.model.payloads.GetProcessInstancesPayload;
+
 import java.util.Set;
 import java.util.UUID;
 
-import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
-import org.activiti.api.process.model.payloads.GetProcessInstancesPayload;
-import org.springframework.stereotype.Component;
-
-@Component
 public class SecurityPoliciesProcessInstanceRestrictionApplier implements SecurityPoliciesRestrictionApplier<GetProcessInstancesPayload> {
 
     @Override

--- a/activiti-spring-security-policies/src/main/java/org/activiti/core/common/spring/security/policies/conf/SecurityPoliciesProperties.java
+++ b/activiti-spring-security-policies/src/main/java/org/activiti/core/common/spring/security/policies/conf/SecurityPoliciesProperties.java
@@ -1,18 +1,13 @@
 package org.activiti.core.common.spring.security.policies.conf;
 
 import org.activiti.core.common.spring.security.policies.SecurityPolicy;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Configuration
 @ConfigurationProperties("activiti.security")
-@Component
-public class SecurityPoliciesProperties implements InitializingBean {
+public class SecurityPoliciesProperties {
 
     private List<SecurityPolicy> policies = new ArrayList<>();
 
@@ -27,8 +22,4 @@ public class SecurityPoliciesProperties implements InitializingBean {
         return wildcard;
     }
 
-    @Override
-    public void afterPropertiesSet() throws Exception {
-        // do nothing
-    }
 }

--- a/activiti-spring-security-policies/src/main/java/org/activiti/core/common/spring/security/policies/config/ActivitiSpringSecurityPoliciesAutoConfiguration.java
+++ b/activiti-spring-security-policies/src/main/java/org/activiti/core/common/spring/security/policies/config/ActivitiSpringSecurityPoliciesAutoConfiguration.java
@@ -1,0 +1,48 @@
+package org.activiti.core.common.spring.security.policies.config;
+
+import org.activiti.api.process.model.payloads.GetProcessDefinitionsPayload;
+import org.activiti.api.process.model.payloads.GetProcessInstancesPayload;
+import org.activiti.api.runtime.shared.identity.UserGroupManager;
+import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.activiti.core.common.spring.security.policies.ProcessSecurityPoliciesManager;
+import org.activiti.core.common.spring.security.policies.ProcessSecurityPoliciesManagerImpl;
+import org.activiti.core.common.spring.security.policies.SecurityPoliciesProcessDefinitionRestrictionApplier;
+import org.activiti.core.common.spring.security.policies.SecurityPoliciesProcessInstanceRestrictionApplier;
+import org.activiti.core.common.spring.security.policies.SecurityPoliciesRestrictionApplier;
+import org.activiti.core.common.spring.security.policies.conf.SecurityPoliciesProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(SecurityPoliciesProperties.class)
+public class ActivitiSpringSecurityPoliciesAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessSecurityPoliciesManager processSecurityPoliciesManager(UserGroupManager userGroupManager,
+                                                                         SecurityManager securityManager,
+                                                                         SecurityPoliciesProperties securityPoliciesProperties,
+                                                                         SecurityPoliciesRestrictionApplier<GetProcessDefinitionsPayload> processDefinitionRestrictionApplier,
+                                                                         SecurityPoliciesRestrictionApplier<GetProcessInstancesPayload> processInstanceRestrictionApplier) {
+        return new ProcessSecurityPoliciesManagerImpl(userGroupManager, 
+                                                      securityManager, 
+                                                      securityPoliciesProperties, 
+                                                      processDefinitionRestrictionApplier, 
+                                                      processInstanceRestrictionApplier);
+    }
+    
+    @Bean
+    @ConditionalOnMissingBean(name = "processInstanceRestrictionApplier")
+    public SecurityPoliciesRestrictionApplier<GetProcessInstancesPayload> processInstanceRestrictionApplier() {
+        return new SecurityPoliciesProcessInstanceRestrictionApplier();
+    }
+    
+    @Bean
+    @ConditionalOnMissingBean(name = "processDefinitionRestrictionApplier")
+    public SecurityPoliciesRestrictionApplier<GetProcessDefinitionsPayload> processDefinitionRestrictionApplier () {
+        return new SecurityPoliciesProcessDefinitionRestrictionApplier();
+    }
+    
+}

--- a/activiti-spring-security-policies/src/main/resources/META-INF/spring.factories
+++ b/activiti-spring-security-policies/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.activiti.core.common.spring.security.policies.config.ActivitiSpringSecurityPoliciesAutoConfiguration

--- a/activiti-spring-security-policies/src/test/java/org/activiti/core/common/spring/security/policies/Application.java
+++ b/activiti-spring-security-policies/src/test/java/org/activiti/core/common/spring/security/policies/Application.java
@@ -2,10 +2,8 @@ package org.activiti.core.common.spring.security.policies;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-@ComponentScan(basePackages = {"org.activiti.core.common.spring.identity", "org.activiti.core.common.spring.security"})
 public class Application {
 
     public static void main(String[] args) {

--- a/activiti-spring-security/pom.xml
+++ b/activiti-spring-security/pom.xml
@@ -28,14 +28,19 @@
       <artifactId>spring-security-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    
+    <!-- Optional -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
+    </dependency>
+    
+    <!-- Test -->    
     <dependency>
       <groupId>org.activiti.core.common</groupId>
       <artifactId>activiti-spring-identity</artifactId>

--- a/activiti-spring-security/pom.xml
+++ b/activiti-spring-security/pom.xml
@@ -16,10 +16,6 @@
       <artifactId>activiti-api-runtime-shared</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>
@@ -28,8 +24,12 @@
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-security</artifactId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/activiti-spring-security/src/main/java/org/activiti/core/common/spring/security/LocalSpringSecurityManager.java
+++ b/activiti-spring-security/src/main/java/org/activiti/core/common/spring/security/LocalSpringSecurityManager.java
@@ -2,12 +2,10 @@ package org.activiti.core.common.spring.security;
 
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 
 /*
  * This is a simple wrapper for Spring Security Context Holder
  */
-@Component
 public class LocalSpringSecurityManager implements SecurityManager {
 
     public String getAuthenticatedUserId() {

--- a/activiti-spring-security/src/main/java/org/activiti/core/common/spring/security/config/ActivitiSpringSecurityAutoConfiguration.java
+++ b/activiti-spring-security/src/main/java/org/activiti/core/common/spring/security/config/ActivitiSpringSecurityAutoConfiguration.java
@@ -1,0 +1,18 @@
+package org.activiti.core.common.spring.security.config;
+
+import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.activiti.core.common.spring.security.LocalSpringSecurityManager;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ActivitiSpringSecurityAutoConfiguration {
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public SecurityManager securityManager() {
+        return new LocalSpringSecurityManager();
+    }
+
+}

--- a/activiti-spring-security/src/main/resources/META-INF/spring.factories
+++ b/activiti-spring-security/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.activiti.core.common.spring.security.config.ActivitiSpringSecurityAutoConfiguration

--- a/activiti-spring-security/src/test/java/org/activiti/core/common/spring/security/LocalSpringSecurityManagerTest.java
+++ b/activiti-spring-security/src/test/java/org/activiti/core/common/spring/security/LocalSpringSecurityManagerTest.java
@@ -1,0 +1,36 @@
+package org.activiti.core.common.spring.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.junit4.SpringRunner;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class LocalSpringSecurityManagerTest {
+
+    @MockBean
+    private UserDetailsService userDetailsService;
+    
+    @Autowired
+    private SecurityManager securityManager;
+    
+    @Test
+    public void contextLoads() {
+        assertThat(securityManager).isInstanceOf(LocalSpringSecurityManager.class);
+    }
+    
+    @SpringBootApplication
+    static class Application {
+        
+    }
+
+}


### PR DESCRIPTION
This PR removes `@ComponentScan` from Spring Boot `@Configuration` classes. The component scan is replaced with explicit auto configuration 

Depends on https://github.com/Activiti/activiti-api/pull/148

Part of https://github.com/Activiti/Activiti/pull/2904

Fixes https://github.com/Activiti/Activiti/issues/1399